### PR TITLE
Remove unicode utils dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,19 +6,32 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
+    activesupport (4.2.1)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    i18n (0.7.0)
     json (1.8.1)
     minitest (5.3.3)
+    minitest-stub-const (0.4)
     rake (10.3.1)
     rdoc (4.1.1)
       json (~> 1.4)
+    thread_safe (0.3.5)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
     unicode_utils (1.4.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport
   gender_detector!
   minitest
+  minitest-stub-const
   rake
   rdoc
   unicode_utils (>= 1.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     gender_detector (0.1.2)
-      unicode_utils (>= 1.3.0)
 
 GEM
   remote: http://rubygems.org/
@@ -22,3 +21,4 @@ DEPENDENCIES
   minitest
   rake
   rdoc
+  unicode_utils (>= 1.3.0)

--- a/README.rdoc
+++ b/README.rdoc
@@ -1,7 +1,7 @@
 = Gender Detector
 {<img src="https://secure.travis-ci.org/bmuller/gender_detector.png?branch=master" alt="Build Status" />}[https://travis-ci.org/bmuller/gender_detector]
 
-Gender Detector is a Ruby library that will tell you the most likely gender of a person based on first name.  It uses the underlying data from the program "gender" by Jorg Michael (described {here}[http://www.autohotkey.com/community/viewtopic.php?t=22000]).  
+Gender Detector is a Ruby library that will tell you the most likely gender of a person based on first name.  It uses the underlying data from the program "gender" by Jorg Michael (described {here}[http://www.autohotkey.com/community/viewtopic.php?t=22000]).
 
 == Installation
 
@@ -32,7 +32,11 @@ Its use is pretty straightforward:
 
 The result will be one of andy (androgynous), male, female, mostly_male, or mostly_female.  Any unknown names are considered andies.
 
-I18N is fully supported:
+I18N is supported if either UnicodeUtils or ActiveSupport are present. To get I18n support, add either one to your Gemfile:
+
+  gem 'unicode_utils' # or gem 'activesupport'
+
+Afterwards, gender detection will work for names with non-ASCII characters as well:
 
   >> d.get_gender("Álfrún")
   :female

--- a/gender_detector.gemspec
+++ b/gender_detector.gemspec
@@ -17,7 +17,9 @@ Gem::Specification.new do |s|
   s.required_ruby_version = Gem::Requirement.new(">= 1.9.0")
 
   s.add_development_dependency('minitest')
+  s.add_development_dependency('minitest-stub-const')
   s.add_development_dependency("rake")
   s.add_development_dependency("rdoc")
   s.add_development_dependency('unicode_utils', '>= 1.3.0')
+  s.add_development_dependency('activesupport')
 end

--- a/gender_detector.gemspec
+++ b/gender_detector.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |s|
   s.files = Dir['lib/**/*.rb'] | Dir['lib/**/data/nam_dict.txt']
   s.required_ruby_version = Gem::Requirement.new(">= 1.9.0")
 
-  s.add_dependency('unicode_utils', '>= 1.3.0')
   s.add_development_dependency('minitest')
   s.add_development_dependency("rake")
   s.add_development_dependency("rdoc")
+  s.add_development_dependency('unicode_utils', '>= 1.3.0')
 end

--- a/lib/gender_detector.rb
+++ b/lib/gender_detector.rb
@@ -1,7 +1,5 @@
 require 'gender_detector/version'
 
-require "unicode_utils/downcase"
-
 class GenderDetector
   COUNTRIES = [ :great_britain, :ireland, :usa, :italy, :malta, :portugal, :spain, :france, :belgium, :luxembourg, :the_netherlands, :east_frisia,
                 :germany, :austria, :swiss, :iceland, :denmark, :norway, :sweden, :finland, :estonia, :latvia, :lithuania, :poland, :czech_republic,
@@ -54,12 +52,12 @@ class GenderDetector
   end
 
   def name_exists?(name)
-    name = UnicodeUtils.downcase(name) unless @case_sensitive
+    name = downcase(name) unless @case_sensitive
     @names.has_key?(name) ? name : false
   end
 
   def get_gender(name, country = nil)
-    name = UnicodeUtils.downcase(name) unless @case_sensitive
+    name = downcase(name) unless @case_sensitive
 
     if not name_exists?(name)
       @unknown_value
@@ -93,7 +91,7 @@ class GenderDetector
 
     parts = line.split(" ").select { |p| p.strip != "" }
     country_values = line.slice(30, line.length)
-    name = @case_sensitive ? parts[1] : UnicodeUtils.downcase(parts[1])
+    name = @case_sensitive ? parts[1] : downcase(parts[1])
 
     case parts[0]
     when "M" then set(name, :male, country_values)
@@ -130,4 +128,13 @@ class GenderDetector
       @names[name][gender] = country_values
     end
   end
+
+  private
+    def downcase(name)
+      if defined?(UnicodeUtils)
+        UnicodeUtils.downcase(name)
+      else
+        name.downcase
+      end
+    end
 end

--- a/lib/gender_detector.rb
+++ b/lib/gender_detector.rb
@@ -133,6 +133,8 @@ class GenderDetector
     def downcase(name)
       if defined?(UnicodeUtils)
         UnicodeUtils.downcase(name)
+      elsif defined?(ActiveSupport::Multibyte::Chars)
+        name.mb_chars.downcase.to_s
       else
         name.downcase
       end

--- a/test/gender_detector_test.rb
+++ b/test/gender_detector_test.rb
@@ -37,4 +37,11 @@ class GenderDetectorTest < MiniTest::Test
     assert d.name_exists?("Carlos")
     assert d.name_exists?("Rosario")
   end
+
+  def test_works_without_dependencies
+    Object.send(:remove_const, :UnicodeUtils)
+    d = GenderDetector.new(:case_sensitive => false)
+    assert_equal :male, d.get_gender("Bob")
+    assert_equal :andy, d.get_gender("ÁLFRÚN") # doesn't work on unicode names anymore
+  end
 end


### PR DESCRIPTION
This addresses issue #2 and removes the unicode_utils dependency. I added the gem `minitest-stub-const` to pretend the UnicodeUtils and ActiveSupport are not present. I hope that's ok.

This is a breaking change (as unicode names won't work out of the box anymore), so the version should probably be bumped to 0.2.0 - I couldn't find an appropriate place in the README to put the update notice.

If I need to do anything else just ping me.

All the best,
Fabian