### PR TITLE
Remove deprecated ActiveSupport::Multibyte::Chars method

### DIFF
--- a/gender_detector.gemspec
+++ b/gender_detector.gemspec
@@ -15,8 +15,6 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.files = Dir['lib/**/*.rb'] | Dir['lib/**/data/nam_dict.txt']
   s.required_ruby_version = Gem::Requirement.new('>= 2.4.0')
-  s.post_install_message = "For unicode support you'll need to also "
-  s.post_install_message += 'install the unicode_utils or activesupport gem'
 
   s.add_development_dependency('minitest', '~> 5.11')
   s.add_development_dependency('minitest-stub-const', '~> 0.6')

--- a/lib/gender_detector.rb
+++ b/lib/gender_detector.rb
@@ -143,10 +143,6 @@ class GenderDetector
   end
 
   def downcase(name)
-    if defined?(ActiveSupport::Multibyte::Chars)
-      name.mb_chars.downcase.to_s
-    else
-      name.downcase
-    end
+    name.downcase
   end
 end

--- a/test/gender_detector_test.rb
+++ b/test/gender_detector_test.rb
@@ -2,7 +2,7 @@ require 'minitest/autorun'
 require 'minitest/stub_const'
 require 'gender_detector'
 
-class GenderDetectorTest < MiniTest::Test
+class GenderDetectorTest < Minitest::Test
   def setup
     @d = GenderDetector.new
   end


### PR DESCRIPTION
Remove deprecated ActiveSupport::Multibyte::Chars method `mb_chars`.

- Also fixed naming of MiniTest to Minitest
- Removed post install message for active support